### PR TITLE
refactor(toaster): derive theme from document

### DIFF
--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,14 +1,16 @@
-import { useTheme } from "next-themes";
 import { Toaster as Sonner, toast } from "sonner";
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme();
+  const theme: ToasterProps["theme"] =
+    typeof document !== "undefined" && document.documentElement.classList.contains("dark")
+      ? "dark"
+      : "light";
 
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme={theme}
       className="toaster group"
       toastOptions={{
         classNames: {


### PR DESCRIPTION
## Summary
- remove the dependency on `useTheme` in the Sonner toaster wrapper
- derive the toaster theme directly from the document element

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68dd75b71a8883279d85b05881d651a0