### PR TITLE
Handle Playwright installs behind proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ npm i
 npm run dev
 ```
 
+### Working with Playwright behind a proxy
+
+The build now attempts to download Playwright browsers automatically, but restricted networks may still block the download.
+If you need to populate the Playwright cache manually, you can do so on a machine with open internet access and copy it over:
+
+1. Run `npx playwright install --with-deps` on the machine that has access.
+2. Locate the generated cache directory (typically `~/.cache/ms-playwright`).
+3. Copy that directory to the same path on the target machine that is behind the proxy.
+
+Once the cache is in place, Playwright can run locally without re-downloading the browsers.
+
 **Edit a file directly in GitHub**
 
 - Navigate to the desired file(s).

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "node scripts/prebuild-playwright.mjs",
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",

--- a/scripts/prebuild-playwright.mjs
+++ b/scripts/prebuild-playwright.mjs
@@ -1,0 +1,36 @@
+import { execSync } from 'node:child_process';
+
+const command = 'npx playwright install --with-deps';
+
+try {
+  console.log(`Running: ${command}`);
+  execSync(command, { stdio: 'inherit' });
+  console.log('Playwright browsers installed successfully.');
+} catch (error) {
+  console.warn('\n⚠️  Warning: Unable to install Playwright browsers automatically.');
+  console.warn('This often happens when downloads are blocked by a proxy or HTTP 403 response.');
+
+  if (error instanceof Error) {
+    if ('status' in error && typeof error.status === 'number') {
+      console.warn(`Exit status: ${error.status}`);
+    }
+
+    const stderr =
+      error && typeof error === 'object' && 'stderr' in error && error.stderr instanceof Buffer
+        ? error.stderr
+        : undefined;
+
+    if (stderr) {
+      const message = stderr.toString().trim();
+      if (message) {
+        console.warn('\nPlaywright output:\n');
+        console.warn(message);
+      }
+    } else if (error.message) {
+      console.warn(error.message);
+    }
+  }
+
+  console.warn('\nContinuing without Playwright browser downloads.');
+  process.exitCode = 0;
+}


### PR DESCRIPTION
## Summary
- add a prebuild runner that installs Playwright browsers and logs a warning when downloads fail
- point the npm prebuild script at the new runner so builds continue even if Playwright cannot download
- document how to populate the Playwright cache manually when working behind a proxy

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd8257d96883278539d49970470576